### PR TITLE
Use isomorphic useLayoutEffect

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,7 @@
-import React, { useRef, useCallback, useEffect } from 'react';
+import React, { useRef, useCallback } from 'react';
 import Head from 'next/head';
 import { useDispatch } from 'react-redux';
+import { useIsomorphicLayoutEffect } from 'react-use';
 import { gsap } from 'gsap';
 
 import styles from './index.module.scss';
@@ -23,11 +24,11 @@ function Landing() {
     dispatch(setLandingLoaded(true));
   }, [dispatch]);
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     animateInInit();
   }, [animateInInit]);
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     animateIn();
   }, [animateIn]);
 


### PR DESCRIPTION
<!--
Please make sure to read the Contributing Guidelines: CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the PR Title -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**Did you test your solution?**

- [x] I lightly tested it in one browser
- [ ] I deeply tested it in several browsers
- [ ] I wrote tests around it (unit tests, integration tests, E2E tests)

## Problem Description

When we do initial animations we usually use useLayoutEffect to wait for the DOM to render since useEffect sometimes makes the website flash for a very small amount of time (like 50ms) which is noticeable on the first hard refresh. 

Using useLayoutEffect throws a warning with nextjs because it has no use in the server

## Solution Description

Swap useLayoutEffect that you want to wait for the DOM to render with useIsomorphicLayoutEffect

Someone smarter than me explained it here
https://medium.com/@alexandereardon/uselayouteffect-and-ssr-192986cdcf7a

## Side Effects, Risks, Impact

- [x] N/A

**Aditional comments:**

You should still use useEffect as normal

We could also just create our own hook since this is essentially just this:
```js
const useIsomorphicLayoutEffect =
  typeof window !== 'undefined' ? useLayoutEffect : useEffect
```
