### PR TITLE
Remove LICENSE file as blacklisted root-file

### DIFF
--- a/.adviserrc.json
+++ b/.adviserrc.json
@@ -19,7 +19,7 @@
           ".stylelintrc",
           "README.md"
         ],
-        "blacklist": ["LICENSE"]
+        "blacklist": []
       }
     ],
     "lighthouse/scores": [


### PR DESCRIPTION
We need to remove LICENSE as a blacklisted file since builds are failing because adviser root-files rule 

The generator should keep the LICENSE MIT since it will be an open source project
When we clone or download the zip for client work we have to remove the LICENSE since is not MIT open source at that point

May be worthy to add this info in the Get Started 