### PR TITLE
Export /page-name/index.html

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -67,6 +67,7 @@ const nextJSConfig = {
     CUSTOM_KEY: process.env.CUSTOM_KEY,
     CUSTOM_ENV: process.env.CUSTOM_ENV
   },
+  exportTrailingSlash: true,
   // compress: true, // NOTE: enable this when doing SSR
   devIndicators: {
     autoPrerender: false


### PR DESCRIPTION
Change
---
- Add `exportTrailingSlash: true` option in the next config

Current behavior
---
-  It generates `[page-name].html` when exporting static HTML

Expected behavior
---
- Exporting `/[page-name]/index.html`