### PR TITLE
[#23] [Fix] Linter script glob pattern Windows support

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "linters": "npm-run-all -p js-lint sass-lint adviser-dev",
     "adviser-dev": "adviser --tags dev --verbose",
     "adviser-ci": "adviser --tags lighthouse,stage --verbose --quiet",
-    "js-lint": "eslint './src/**/*.js' -c ./.eslintrc.json --quiet --ignore-pattern .gitignore",
-    "sass-lint": "stylelint './src/**/*.scss'"
+    "js-lint": "eslint \"./src/**/*.js\" -c ./.eslintrc.json --quiet --ignore-pattern .gitignore",
+    "sass-lint": "stylelint \"./src/**/*.scss\""
   },
   "dependencies": {
     "@jam3/detect": "1.0.2",


### PR DESCRIPTION
Fix for: https://github.com/Jam3/nyg-nextjs/issues/23

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

**Did you test your solution?**

~~- [ ] I lightly tested it in one browser~~
~~- [ ] I deeply tested it in several browsers~~
~~- [ ] I wrote tests around it (unit tests, integration tests, E2E tests)~~

Issue applies only to pre-commit scripts, I tested it on my Windows machine, and on my Macbook to ensure the glob pattern works for both

## Problem Description

Linter script glob pattern doesn't work on Windows

## Solution Description

Double-quoted the glob pattern

## Side Effects, Risks, Impact

<!--- May your changes break other parts of the application? -->

- [X] N/A

**Aditional comments:**

Found the solution here: https://stackoverflow.com/questions/51021751/express-js-lint-gives-mistake
