### PR TITLE
fix: lint-staged issue when having dynamic pages

### DIFF
--- a/.adviserrc.json
+++ b/.adviserrc.json
@@ -4,7 +4,7 @@
     "package-json-properties": [
       "error",
       {
-        "required": ["name", "private", "scripts", "engines", "dependencies", "lint-staged", "husky", "browserslist"]
+        "required": ["name", "private", "scripts", "engines", "dependencies", "husky", "browserslist"]
       }
     ],
     "root-files": [

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,20 @@
+const escape = require('shell-quote').quote;
+const isWin = process.platform === 'win32';
+
+module.exports = {
+  '**/*.{js,jsx,ts,tsx}': filenames => {
+    const escapedFileNames = filenames.map(filename => `"${isWin ? filename : escape([filename])}"`).join(' ');
+    return [
+      `prettier --with-node-modules --ignore-path .prettierignore_staged --write ${escapedFileNames}`,
+      `eslint --no-ignore --max-warnings=0 --fix ${filenames.map(f => `"${f}"`).join(' ')}`,
+      `git add ${escapedFileNames}`
+    ];
+  },
+  '**/*.{json,md,mdx,css,html,yml,yaml,scss}': filenames => {
+    const escapedFileNames = filenames.map(filename => `"${isWin ? filename : escape([filename])}"`).join(' ');
+    return [
+      `prettier --with-node-modules --ignore-path .prettierignore_staged --write ${escapedFileNames}`,
+      `git add ${escapedFileNames}`
+    ];
+  }
+};

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "component": "node scripts/component.js",
     "page": "node scripts/component.js --page",
     "\n ######################  Automation Tools  ######################": "",
+    "lint-staged": "lint-staged",
     "linters": "npm-run-all -p js-lint sass-lint adviser-dev",
     "adviser-dev": "adviser --tags dev --verbose",
     "adviser-ci": "adviser --tags lighthouse,stage --verbose --quiet",
@@ -112,6 +113,7 @@
     "prop-types": "^15.7.2",
     "redux-devtools-extension": "2.13.8",
     "serve": "^11.3.0",
+    "shell-quote": "^1.7.2",
     "stylelint": "13.0.0",
     "stylelint-config-jam3": "0.1.2",
     "webp-loader": "0.6.0"
@@ -122,11 +124,6 @@
   "engines": {
     "node": ">=10.15.0",
     "npm": ">=6.5.0"
-  },
-  "lint-staged": {
-    "src/**/*.{js,json,scss}": [
-      "prettier --write"
-    ]
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
An issue is occurred when working with dynamic page/routing. lint-staged fails due to the file name that is wrapped brackets. 

Opened issue: https://github.com/okonet/lint-staged/issues/676

Reference: https://github.com/zeit/next.js/blob/canary/lint-staged.config.js