### PR TITLE
fix: robots.txt per environment

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,8 +1,3 @@
 # Development configuration
 User-agent: *
 Disallow: /
-
-# Production configuration
-# Sitemap: https://[final-domain]/sitemap.xml
-# User-agent: *
-# Disallow: [routes behind login]

--- a/scripts/robots-txt-generator.js
+++ b/scripts/robots-txt-generator.js
@@ -7,28 +7,15 @@ require('dotenv').config({
   path: path.resolve(process.cwd(), `.env.${process.env.BUILD_ENV || process.env.NODE_ENV}`)
 });
 
-if (process.env.WEBSITE_SITE_URL) {
+if (process.env.CI_ENV === 'production' && process.env.WEBSITE_SITE_URL) {
   console.log(chalk.cyan('\n###################### robots.txt ######################\n'));
 
   robotstxt({
     policy: [
       {
-        userAgent: 'Googlebot',
-        allow: '/',
-        disallow: ['/assets', '/_next'],
-        crawlDelay: 2
-      },
-      {
-        userAgent: 'OtherBot',
-        allow: '/',
-        disallow: ['/assets', '/_next'],
-        crawlDelay: 2
-      },
-      {
         userAgent: '*',
         allow: '/',
-        disallow: ['/assets', '/_next'],
-        crawlDelay: 10
+        disallow: ['/_next']
       }
     ],
     sitemap: `${process.env.WEBSITE_SITE_URL}/sitemap.xml`,


### PR DESCRIPTION
# Changelog
Refine robots.txt, and make sure the full indexable version is used only on production environments.

## Tasks executed
- [x] Use always the full disallow version on non-production environments
- [x] Refine production robots.txt to only one agent, allowing everything except the bundle folder

## Implementation notes
Make sure that in your **production CI pipeline**, you specify the environment variable `CI_ENV=production`
