### PR TITLE
fix: remove webpack css minify config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,7 +5,6 @@ require('dotenv').config({
 });
 
 const withPlugins = require('next-compose-plugins');
-const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const optimizedImages = require('next-optimized-images');
 const withFonts = require('next-fonts');
 const withBundleAnalyzer = require('@next/bundle-analyzer')({
@@ -66,18 +65,6 @@ const nextJSConfig = {
         'url-loader'
       ]
     });
-
-    if (config.mode === 'production') {
-      if (Array.isArray(config.optimization.minimizer)) {
-        config.optimization.minimizer.push(
-          new OptimizeCSSAssetsPlugin({
-            cssProcessorPluginOptions: {
-              preset: ['default', { discardComments: { removeAll: true } }]
-            }
-          })
-        );
-      }
-    }
 
     return config;
   }

--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
     "nextjs-sitemap-generator": "^0.5.0",
     "node-sass": "^4.13.1",
     "npm-run-all": "^4.1.5",
-    "optimize-css-assets-webpack-plugin": "^5.0.3",
     "prettier": "1.19.1",
     "prop-types": "^15.7.2",
     "redux-devtools-extension": "2.13.8",


### PR DESCRIPTION
NOTE: 
- `optimize-css-assets-webpack-plugin` is no longer required. NextJS is now supporting this by default for a production build.