### PR TITLE
Fix: Link Functional Component Forward Ref

### DIFF
--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -25,7 +25,10 @@ function Nav() {
         <ul className={styles.routes}>
           <li>
             <Link href="/">
-              <SvgThreeLogo className={styles.threeLogo} />
+              {/* eslint-disable-next-line jsx-a11y/anchor-is-valid*/}
+              <a>
+                <SvgThreeLogo className={styles.threeLogo} />
+              </a>
             </Link>
           </li>
 


### PR DESCRIPTION
Removing console error caused by Link having a functional component as a child.

https://github.com/vercel/next.js/issues/7915