### PR TITLE
[FIX] Environment Variables on Browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "babel-preset-react-app": "^9.1.1",
     "chalk": "^3.0.0",
     "cross-env": "^7.0.0",
-    "dotenv": "8.2.0",
     "eslint": "6.8.0",
     "eslint-config-postcss": "3.0.7",
     "eslint-config-prettier": "6.10.0",


### PR DESCRIPTION
<!--
Please make sure to read the Contributing Guidelines: CONTRIBUTING.md
-->

<!--- Provide a general summary of your changes in the PR Title -->

**What kind of change does this PR introduce?** (check at least one)

- [*] Bugfix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Code style update
- [ ] Refactor (refactoring or adding test which isn't a fix or add a feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [*] No

**Did you test your solution?**

- [*] I lightly tested it in one browser
- [ ] I deeply tested it in several browsers
- [ ] I wrote tests around it (unit tests, integration tests, E2E tests)

## Problem Description

Environment variables are not working on the browser  when using the NEXT_PUBLIC prefix.
![Screen Shot 2020-07-25 at 9 05 45 AM](https://user-images.githubusercontent.com/42558504/88457863-c02ef180-ce57-11ea-8053-781ce7e59c07.png)
<img width="436" alt="Screen Shot 2020-07-25 at 9 06 42 AM" src="https://user-images.githubusercontent.com/42558504/88457866-c329e200-ce57-11ea-982a-3b6dc9e8dbc4.png">

## Solution Description

https://github.com/vercel/next.js/discussions/12815

## Side Effects, Risks, Impact

<!--- May your changes break other parts of the application? -->

I noticed that dotenv is being used in:
```
next.config.js
nextjs.sitemap-generator.js
robots-txt-generator.js
```
But productions builds still work even after uninstalling the package. Might be worth double checking though. 👍 
