### PR TITLE
Feature: Access Sass Variables within Javascript

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -47,6 +47,15 @@ const nextJSConfig = {
     modern: true
   },
   webpack: function (config, options) {
+    const moduleSassRule = config.module.rules[1].oneOf.find(
+      (rule) => rule.test.toString() === /\.module\.(scss|sass)$/.toString()
+    );
+
+    if (moduleSassRule) {
+      const cssLoader = moduleSassRule.use.find(({ loader }) => loader.includes('css-loader'));
+      if (cssLoader) cssLoader.options.modules.mode = 'local';
+    }
+
     return config;
   }
 };

--- a/src/styles/export-vars.module.scss
+++ b/src/styles/export-vars.module.scss
@@ -1,0 +1,12 @@
+/* stylelint-disable */
+@import 'shared.scss';
+
+:export {
+  white: $white;
+  black: $black;
+  layoutMobile: $layout-mobile;
+  layoutTablet: $layout-tablet;
+  layoutDesktopSm: $layout-desktopSm;
+  layoutDesktopMd: $layout-desktopMd;
+  layoutDesktopLg: $layout-desktopLg;
+}

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -5,14 +5,6 @@
 @import 'polyfills.scss';
 @import 'shared.scss';
 
-:root {
-  --layout-mobile: #{$layout-mobile};
-  --layout-tablet: #{$layout-tablet};
-  --layout-desktop-sm: #{$layout-desktopSm};
-  --layout-desktop-md: #{$layout-desktopMd};
-  --layout-desktop-lg: #{$layout-desktopLg};
-}
-
 html {
   box-sizing: border-box;
   -moz-osx-font-smoothing: grayscale;

--- a/src/utils/layout.js
+++ b/src/utils/layout.js
@@ -1,20 +1,13 @@
 import { isBrowser } from './detect';
+import { layoutTablet, layoutDesktopSm, layoutDesktopMd, layoutDesktopLg } from '../styles/export-vars.module.scss';
 
 function getLayout() {
   if (!isBrowser) return {};
 
-  const TABLET_MEDIA_QUERY = `(min-width: ${getComputedStyle(document.documentElement).getPropertyValue(
-    '--layout-tablet'
-  )})`;
-  const DESKTOP_SM_MEDIA_QUERY = `(min-width: ${getComputedStyle(document.documentElement).getPropertyValue(
-    '--layout-desktop-sm'
-  )})`;
-  const DESKTOP_MD_MEDIA_QUERY = `(min-width: ${getComputedStyle(document.documentElement).getPropertyValue(
-    '--layout-desktop-md'
-  )})`;
-  const DESKTOP_LG_MEDIA_QUERY = `(min-width: ${getComputedStyle(document.documentElement).getPropertyValue(
-    '--layout-desktop-lg'
-  )})`;
+  const TABLET_MEDIA_QUERY = `(min-width: ${layoutTablet})`;
+  const DESKTOP_SM_MEDIA_QUERY = `(min-width: ${layoutDesktopSm})`;
+  const DESKTOP_MD_MEDIA_QUERY = `(min-width: ${layoutDesktopMd})`;
+  const DESKTOP_LG_MEDIA_QUERY = `(min-width: ${layoutDesktopLg})`;
 
   const TABLET_MATCH_MEDIA = window.matchMedia(TABLET_MEDIA_QUERY);
   const DESKTOP_SM_MATCH_MEDIA = window.matchMedia(DESKTOP_SM_MEDIA_QUERY);


### PR DESCRIPTION
Currently when we want to access a Sass variable within JavaScript, we add it to a CSS variable and retrieve using `getPropertyValue('--var')`. Now that we're SSR'ing, we are only able to access these variables on the browser side. Due to this limitation, this feature adds the ability to import sass variables directly in our JavaScript files that works on server side.

Caveats: 
1) Requires overwriting a cssLoader option. (https://github.com/vercel/next.js/issues/11629)
2) Scss export file is required to be a `.module.scss` otherwise NextJS will throw error (https://github.com/vercel/next.js/blob/master/errors/css-global.md).

