### PR TITLE
Feature: Make Head separate component

### DIFF
--- a/scripts/templates/page/Page.js
+++ b/scripts/templates/page/Page.js
@@ -1,18 +1,17 @@
 import React, { memo } from 'react';
 import classnames from 'classnames';
 import checkProps from '@jam3/react-check-extra-props';
-import Head from 'next/head';
 
 import styles from './{{name}}.module.scss';
+
+import Head from '../../components/Head/Head';
 
 import { withRedux } from '../../redux/withRedux';
 
 function {{name}}() {
   return (
     <section className={classnames(styles.{{name}})}>
-      <Head>
-        <title>{{name}} | Jam3 generator</title>
-      </Head>
+      <Head title="{{name}}" />
 
       <section>{{name}} Page</section>
     </section>

--- a/src/components/Head/Head.js
+++ b/src/components/Head/Head.js
@@ -8,12 +8,12 @@ import { siteName, siteSlogan } from '../../data/settings';
 const TITLE_SEPARATOR = '|';
 
 function Head({ title, description, keywords }) {
+  const fullTitle = title ? `${title} ${TITLE_SEPARATOR} ${siteName}` : `${siteName} ${TITLE_SEPARATOR} ${siteSlogan}`;
+
   return (
     <NextHead>
       <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-      <title>
-        {title ? `${title} ${TITLE_SEPARATOR} ${siteName}` : `${siteName} ${TITLE_SEPARATOR} ${siteSlogan}`}
-      </title>
+      <title>{fullTitle}</title>
       <meta name="description" content={description} />
       <meta name="keywords" content={keywords.join()} />
       {/* Generate favicons in https://realfavicongenerator.net */}
@@ -28,11 +28,11 @@ function Head({ title, description, keywords }) {
       <meta name="msapplication-config" content="/favicons/browserconfig.xml" />
       {/* Share meta tags */}
       <meta property="og:locale" content="en_US" />
-      <meta property="og:title" content="Default title" />
-      <meta property="og:description" content="Default title" />
+      <meta property="og:title" content={fullTitle} />
+      <meta property="og:description" content={description} />
       <meta property="og:type" content="website" />
       <meta property="og:url" content={process.env.NEXT_PUBLIC_WEBSITE_SITE_URL} />
-      <meta property="og:site_name" content="Default site name" />
+      <meta property="og:site_name" content={siteName} />
       <meta property="og:image:width" content="1200" />
       <meta property="og:image:height" content="630" />
       <meta property="og:image" content="/_next/static/images/share-image.jpg" />

--- a/src/components/Head/Head.js
+++ b/src/components/Head/Head.js
@@ -1,0 +1,61 @@
+import React, { memo } from 'react';
+import PropTypes from 'prop-types';
+import checkProps from '@jam3/react-check-extra-props';
+import NextHead from 'next/head';
+
+import { siteName, siteSlogan } from '../../data/settings';
+
+const TITLE_SEPARATOR = '|';
+
+function Head({ title, description, keywords }) {
+  return (
+    <NextHead>
+      <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+      <title>
+        {title ? `${title} ${TITLE_SEPARATOR} ${siteName}` : `${siteName} ${TITLE_SEPARATOR} ${siteSlogan}`}
+      </title>
+      <meta name="description" content={description} />
+      <meta name="keywords" content={keywords.join()} />
+      {/* Generate favicons in https://realfavicongenerator.net */}
+      <meta name="theme-color" content="#ffffff" />
+      <meta name="msapplication-TileColor" content="#ffffff" />
+      <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png" />
+      <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png" />
+      <link rel="icon" type="image/png" sizes="16x16" href="/favicons/favicon-16x16.png" />
+      <link rel="manifest" href="/favicons/site.webmanifest" />
+      <link rel="mask-icon" href="/favicons/safari-pinned-tab.svg" color="#000000" />
+      <link rel="shortcut icon" href="/favicons/favicon.ico" />
+      <meta name="msapplication-config" content="/favicons/browserconfig.xml" />
+      {/* Share meta tags */}
+      <meta property="og:locale" content="en_US" />
+      <meta property="og:title" content="Default title" />
+      <meta property="og:description" content="Default title" />
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content={process.env.NEXT_PUBLIC_WEBSITE_SITE_URL} />
+      <meta property="og:site_name" content="Default site name" />
+      <meta property="og:image:width" content="1200" />
+      <meta property="og:image:height" content="630" />
+      <meta property="og:image" content="/_next/static/images/share-image.jpg" />
+      <meta name="twitter:card" content="Default content" />
+      <meta property="fb:app_id" content="FB_APP_ID" />
+      <meta name="google-site-verification" content="[Google Web Master Tools]" />
+      <meta name="msvalidate.01" content="[Bing Web Master Tools]" />
+      {/* Other recommends */}
+      <link rel="canonical" href={process.env.NEXT_PUBLIC_WEBSITE_SITE_URL} />
+      {process.env.NEXT_PUBLIC_DNS_PREFETCH && <link rel="dns-prefetch" href={process.env.NEXT_PUBLIC_DNS_PREFETCH} />}
+    </NextHead>
+  );
+}
+
+Head.propTypes = checkProps({
+  title: PropTypes.string,
+  description: PropTypes.string,
+  keywords: PropTypes.array
+});
+
+Head.defaultProps = {
+  description: 'Default Description',
+  keywords: ['Jam3', 'Web App', 'React', 'NextJS']
+};
+
+export default memo(Head);

--- a/src/components/Head/Head.stories.js
+++ b/src/components/Head/Head.stories.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import Component from './Head';
+
+storiesOf('Head', module).add('Default', () => <Component />);

--- a/src/data/settings.js
+++ b/src/data/settings.js
@@ -1,7 +1,7 @@
-const settings = {};
-
 // global
-settings.resizeDebounceTime = 10; // in ms
-settings.isDevelopment = process.env.NODE_ENV !== 'production';
+export const resizeDebounceTime = 10; // in ms
+export const isDevelopment = process.env.NODE_ENV !== 'production';
 
-export default settings;
+// head
+export const siteName = 'Jam3 Generator';
+export const siteSlogan = 'The Relentless Pursuit of Better';

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import Head from 'next/head';
 import dynamic from 'next/dynamic';
 import 'normalize.css';
 import 'default-passive-events';
@@ -42,42 +41,6 @@ function App({ Component, pageProps }) {
 
   return (
     <Layout>
-      <Head>
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <title>Jam3 generator</title>
-        <meta name="description" content="Default description" />
-        <meta name="keywords" content="Jam3,web App,React" />
-        {/* Generate favicons in https://realfavicongenerator.net */}
-        <meta name="theme-color" content="#ffffff" />
-        <meta name="msapplication-TileColor" content="#ffffff" />
-        <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png" />
-        <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png" />
-        <link rel="icon" type="image/png" sizes="16x16" href="/favicons/favicon-16x16.png" />
-        <link rel="manifest" href="/favicons/site.webmanifest" />
-        <link rel="mask-icon" href="/favicons/safari-pinned-tab.svg" color="#000000" />
-        <link rel="shortcut icon" href="/favicons/favicon.ico" />
-        <meta name="msapplication-config" content="/favicons/browserconfig.xml" />
-        {/* Share meta tags */}
-        <meta property="og:locale" content="en_US" />>
-        <meta property="og:title" content="Default title" />
-        <meta property="og:description" content="Default title" />
-        <meta property="og:type" content="website" />
-        <meta property="og:url" content={process.env.NEXT_PUBLIC_WEBSITE_SITE_URL} />
-        <meta property="og:site_name" content="Default site name" />
-        <meta property="og:image:width" content="1200" />
-        <meta property="og:image:height" content="630" />
-        <meta property="og:image" content="/_next/static/images/share-image.jpg" />
-        <meta name="twitter:card" content="Default content" />
-        <meta property="fb:app_id" content="FB_APP_ID" />
-        <meta name="google-site-verification" content="[Google Web Master Tools]" />
-        <meta name="msvalidate.01" content="[Bing Web Master Tools]" />
-        {/* Other recommends */}
-        <link rel="canonical" href={process.env.NEXT_PUBLIC_WEBSITE_SITE_URL} />
-        {process.env.NEXT_PUBLIC_DNS_PREFETCH && (
-          <link rel="dns-prefetch" href={process.env.NEXT_PUBLIC_DNS_PREFETCH} />
-        )}
-      </Head>
-
       <Component {...pageProps} />
 
       <RotateScreen />

--- a/src/pages/about/index.js
+++ b/src/pages/about/index.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import Head from 'next/head';
 import { useSelector } from 'react-redux';
 
 import styles from '../index.module.scss';
 
+import Head from '../../components/Head/Head';
 import Nav from '../../components/Nav/Nav';
 
 import { withRedux } from '../../redux/withRedux';
@@ -13,9 +13,7 @@ function About() {
 
   return (
     <section className="About">
-      <Head>
-        <title>About | Jam3 generator</title>
-      </Head>
+      <Head title="About" />
 
       <Nav />
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,10 +1,10 @@
 import React, { useRef, useCallback, useEffect } from 'react';
-import Head from 'next/head';
 import { useDispatch } from 'react-redux';
 import { gsap } from 'gsap';
 
 import styles from './index.module.scss';
 
+import Head from '../components/Head/Head';
 import Nav from '../components/Nav/Nav';
 
 import { withRedux } from '../redux/withRedux';
@@ -33,9 +33,7 @@ function Landing() {
 
   return (
     <section className={styles.Landing}>
-      <Head>
-        <title>Home | Jam3 generator</title>
-      </Head>
+      <Head />
 
       <Nav />
 

--- a/src/utils/hooks/use-layout.js
+++ b/src/utils/hooks/use-layout.js
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useWindowSize } from '@jam3/react-hooks';
-import settings from '../../data/settings';
+import { resizeDebounceTime } from '../../data/settings';
 import layout from '../layout';
 
 /**
@@ -13,7 +13,7 @@ import layout from '../layout';
  * const { layout } = useLayout();
  */
 function useLayout() {
-  const { innerWidth } = useWindowSize(settings.resizeDebounceTime);
+  const { innerWidth } = useWindowSize(resizeDebounceTime);
   const [currentLayout, setCurrentLayout] = useState(layout.all);
 
   const handleResize = useCallback(() => {


### PR DESCRIPTION
- Move Head from _app to its own component and contain all Head logic within.
- Easier/Cleaner to specify props from page level such as title, description, keywords etc.
- Add title logic in the format of `Jam3 Generator | The Relentless Pursuit of Better` for home page and `About | Jam3 Generator` for other pages.